### PR TITLE
Clean up continue query

### DIFF
--- a/apps/interactor/src/components/common/TextFormatter.tsx
+++ b/apps/interactor/src/components/common/TextFormatter.tsx
@@ -120,8 +120,13 @@ const TextFormatter: React.FC<TextFormatterProps> = ({ text }) => {
 
   useEffect(() => {
     if (!text.startsWith(displayedText)) {
-      setDisplayedText('')
-      setCurrentIndex(0)
+      if (displayedText.startsWith(text)) {
+        setDisplayedText(text)
+        setCurrentIndex(text.length)
+      } else {
+        setDisplayedText('')
+        setCurrentIndex(0)
+      }
     }
   }, [text, displayedText])
 

--- a/apps/interactor/src/libs/memory/PromptBuilder.ts
+++ b/apps/interactor/src/libs/memory/PromptBuilder.ts
@@ -18,10 +18,7 @@ class PromptBuilder {
     this.strategy = this.getStrategyFromSlug(options.strategy)
   }
 
-  public buildPrompt(
-    state: RootState,
-    continueResponse?: boolean
-  ): {
+  public buildPrompt(state: RootState): {
     template: string
     variables: Record<string, string | string[]>
   } {
@@ -54,8 +51,7 @@ class PromptBuilder {
     return this.strategy.buildPrompt(
       state,
       this.options.maxNewTokens,
-      memorySize,
-      continueResponse
+      memorySize
     )
   }
 

--- a/apps/interactor/src/libs/memory/strategies/RoleplayStrategy.ts
+++ b/apps/interactor/src/libs/memory/strategies/RoleplayStrategy.ts
@@ -17,8 +17,7 @@ export class RoleplayStrategy extends AbstractPromptStrategy {
   override buildPrompt(
     state: RootState,
     maxNewTokens: number,
-    memorySize: number,
-    continueResponse?: boolean
+    memorySize: number
   ): {
     template: string
     variables: Record<string, string | string[]>
@@ -55,11 +54,6 @@ export class RoleplayStrategy extends AbstractPromptStrategy {
     template += scenario ? `${scenario}\n` : ''
 
     template += this.getDialogueHistoryPrompt(state, memorySize)
-
-    if (continueResponse) {
-      template +=
-        "\n\n### Instruction: Continue writing {{char}}'s response below."
-    }
 
     template += this.getResponseAskLine(state, maxNewTokens)
 

--- a/apps/interactor/src/state/slices/narrationSlice.ts
+++ b/apps/interactor/src/state/slices/narrationSlice.ts
@@ -6,6 +6,7 @@ import {
   NarrationResponse,
 } from '../versioning'
 import { toast } from 'react-toastify'
+import trim from 'lodash.trim'
 
 export type {
   NarrationState,
@@ -184,12 +185,28 @@ const narrationSlice = createSlice({
     },
     continueResponse(
       state,
-      action: PayloadAction<{
+      // eslint-disable-next-line
+      _action: PayloadAction<{
         servicesEndpoint: string
       }>
     ) {
-      console.log(state) // won't compile if they're unused but i need them in the listener
-      console.log(action)
+      const response = state.responses[state.currentResponseId]
+      const characterResponses = Object.values(response?.characters || {})
+      const lastResponse = characterResponses.length
+        ? characterResponses[0]
+        : null
+      if (!lastResponse) return state
+
+      const continuationTokens = ['\n"', '\n*', '\n*{{char}}']
+      const endingTokens = ['\n', '*', '"', '.']
+      if (endingTokens.some((token) => lastResponse.text.endsWith(token))) {
+        lastResponse.text =
+          trim(lastResponse.text) +
+          continuationTokens[
+            Math.floor(Math.random() * continuationTokens.length)
+          ]
+      }
+      state.input.disabled = false
     },
     swipeResponse(state, action: PayloadAction<string>) {
       const response = state.responses[action.payload]


### PR DESCRIPTION
In this PR:
* Remove `continueResponse` flag. This is not required since `getResponseAskLine` already handles this scenario.
* Add a random `continuationToken` in case the current response ends with a closing token.
* Fixes TextFormatter animations after edit.